### PR TITLE
Reapply credit authorization tests

### DIFF
--- a/Authorization.ts
+++ b/Authorization.ts
@@ -4,7 +4,7 @@ import { http } from "cloudly-http"
 import { Card } from "./Card"
 
 export namespace Authorization {
-	const authorizations = ["succeeding", "failing", "flagless"] as const
+	const authorizations = ["succeeding", "failing", "flagless", "credit"] as const
 	export type Authorizations = typeof authorizations[number]
 	export async function create(
 		client: http.Client,
@@ -25,7 +25,7 @@ export namespace Authorization {
 	): Promise<[Authorizations, pax2pay.Authorization | undefined]> {
 		let card: string | undefined = undefined
 		if (!(type == "failing" && !(currentHour % 6) && currentMinute > 50)) {
-			const created = await Card.create(pax2payClient)
+			const created = await Card.create(pax2payClient, type == "credit" ? "BdJ4riwM" : undefined)
 			!pax2pay.Card.is(created)
 				? console.log(
 						`authorization test ${type} failed due to card creation error: `,
@@ -158,4 +158,5 @@ const creatables: Record<Authorization.Authorizations, Omit<pax2pay.Authorizatio
 				description: "Authorization to fail due to gambling MCC.",
 			},
 		],
+		credit: [{ ...flagless, amount: amount.low, description: flagless.description + " with low amount flag." }],
 	}

--- a/Card.ts
+++ b/Card.ts
@@ -3,8 +3,8 @@ import { pax2pay } from "@pax2pay/model-banking"
 
 export namespace Card {
 	export const currency = "GBP"
-	export async function create(client: pax2pay.Client): Promise<pax2pay.Card | gracely.Error> {
-		return await client.cards.create(creatable)
+	export async function create(client: pax2pay.Client, account?: string): Promise<pax2pay.Card | gracely.Error> {
+		return await client.cards.create(typeof account == "string" ? { ...creatable, account } : creatable)
 	}
 	export const creatable: pax2pay.Card.Creatable = {
 		/* cspell: disable-next-line */

--- a/authorization.spec.ts
+++ b/authorization.spec.ts
@@ -38,6 +38,11 @@ describe("pax2pay.Authorization", () => {
 			console.log("failing", JSON.stringify(authorization?.failing, null, 2))
 		expect(authorization?.failing?.status).not.toEqual("approved")
 	})
+	it("create credit", () => {
+		authorization?.credit?.status !== "approved" &&
+			console.log("credit", JSON.stringify(authorization?.credit, null, 2))
+		expect(authorization?.credit?.status).toEqual("approved")
+	})
 	it("refund", async () => {
 		const now = isoly.DateTime.now()
 		let result: boolean


### PR DESCRIPTION
Still getting 404 errors when fetching cards in auth tests, probably caused by change in worker-card?